### PR TITLE
Implement erase using derive

### DIFF
--- a/.yarn/versions/5e467d26.yml
+++ b/.yarn/versions/5e467d26.yml
@@ -1,0 +1,2 @@
+releases:
+  "@data-wrangling-components/core": patch

--- a/.yarn/versions/5e467d26.yml
+++ b/.yarn/versions/5e467d26.yml
@@ -1,2 +1,6 @@
 releases:
   "@data-wrangling-components/core": patch
+
+declined:
+  - "@data-wrangling-components/react"
+  - "@data-wrangling-components/webapp"

--- a/javascript/core/src/engine/verbs/erase.ts
+++ b/javascript/core/src/engine/verbs/erase.ts
@@ -3,8 +3,7 @@
  * Licensed under the MIT license. See LICENSE file in the project.
  */
 
-import { from } from 'arquero'
-import type { RowObject } from 'arquero/dist/types/table/table'
+import { escape } from 'arquero'
 import { container } from '../../factories.js'
 import type { TableStore } from '../../index.js'
 import type { EraseArgs, Step, TableContainer } from '../../types.js'
@@ -24,13 +23,11 @@ export async function erase(
 	const { value, column } = args as EraseArgs
 	const inputTable = await store.table(input)
 
-	const matrix: RowObject[] = inputTable.objects()
+	const func = escape((d: any) => (d[column] === value ? undefined : d[column]))
 
-	matrix.forEach(row => {
-		if (row[column] === value) {
-			row[column] = undefined
-		}
-	})
+	const dArgs = {
+		[column]: func,
+	}
 
-	return container(output, from(matrix))
+	return container(output, inputTable.derive(dArgs))
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
 		"lint": "essex lint --fix",
 		"git_is_clean": "essex git-is-clean",
 		"prettify": "essex prettify",
+		"test": "yarn jest",
 		"jest": "NODE_OPTIONS=--experimental-vm-modules yarn node $(yarn bin jest)",
 		"ci": "run-s build lint jest git_is_clean",
 		"publish": "yarn workspaces foreach --exclude '@data-wrangling-components/project' -pv npm publish --tolerate-republish --access public",


### PR DESCRIPTION
Reimplements erase using a derive instead of table.objects(). Due to the serialization time for `objects()` and `from()`, this actually results in a 10x performance boost on large tables.