### PR TITLE
March feedback

### DIFF
--- a/.yarn/versions/3f56b1ad.yml
+++ b/.yarn/versions/3f56b1ad.yml
@@ -1,0 +1,4 @@
+releases:
+  "@data-wrangling-components/core": minor
+  "@data-wrangling-components/react": minor
+  "@data-wrangling-components/webapp": patch

--- a/.yarn/versions/3f56b1ad.yml
+++ b/.yarn/versions/3f56b1ad.yml
@@ -2,3 +2,6 @@ releases:
   "@data-wrangling-components/core": minor
   "@data-wrangling-components/react": minor
   "@data-wrangling-components/webapp": patch
+
+declined:
+  - "@data-wrangling-components/guidance"

--- a/docs/verbs/filter.md
+++ b/docs/verbs/filter.md
@@ -1,6 +1,6 @@
 # filter
 
-Creates a filtered table that only contains rows that match specified criteria. Filter can compare the values of an input column to a fixed value (e.g.) `row.value <= 10`), or it can compare to the value of another column in the same row (e.g., `row.value <= row.other_value`). Comparisons can be numeric (=, !=, <, >, etc.) or string-based (equals, contains, starts with, etc.).
+Creates a filtered table that only contains rows that match specified criteria. Filter can compare the values of an input column to a fixed value (e.g.) `row.value <= 10`), or it can compare to the value of another column in the same row (e.g., `row.value <= row.other_value`). Comparisons can be numeric (=, !=, <, >, etc.) or string-based (equals, contains, starts with, etc.). If an empty/not empty filter is _not_ specified but invalid values are found, the result for that comparison will be a negative match.
 
 ## Comparison operators
 

--- a/docs/verbs/join.md
+++ b/docs/verbs/join.md
@@ -1,6 +1,6 @@
 # join
 
-Combines two tables using relational inner join mechanics. A join key (column name) from the input and secondary table can be specified. Only rows with a match on each table are copied. All columns from the secondary table are joined with the input. If a secondary join key is not specified, the primary join key is used for both tables.
+Combines two tables using relational join mechanics. A join key (column name) from the input and secondary table can be specified. All columns from the secondary table are joined with the input. If a secondary join key is not specified, the primary join key is used for both tables. By default an inner join is performed, but left, right, or full joins can be specified.
 
 ## Example
 

--- a/docs/verbs/merge.md
+++ b/docs/verbs/merge.md
@@ -6,7 +6,8 @@ Available collapse strategies are:
 
 - first one wins: the first valid column value is used in the output
 - last one winss: the last valid column value is used in the output
-- concat: all valid column values are concatenated together
+- concat: all valid column values are concatenated together, and a delimiter can be specified
+- array: all valid column values are pushed into a cell array
 
 ## Examples
 

--- a/javascript/core/src/engine/__tests__/binarize.spec.ts
+++ b/javascript/core/src/engine/__tests__/binarize.spec.ts
@@ -183,11 +183,11 @@ describe('test for binarize verb', () => {
 			expect(result.table.numRows()).toBe(6)
 			// test where criteria match
 			expect(result.table.get('newColumn', 0)).toBe(0)
-			expect(result.table.get('newColumn', 1)).toBeUndefined()
+			expect(result.table.get('newColumn', 1)).toBe(0)
 			expect(result.table.get('newColumn', 2)).toBe(1)
 			expect(result.table.get('newColumn', 3)).toBe(1)
 			expect(result.table.get('newColumn', 4)).toBe(0)
-			expect(result.table.get('newColumn', 5)).toBeUndefined()
+			expect(result.table.get('newColumn', 5)).toBe(0)
 		})
 	})
 })

--- a/javascript/core/src/engine/__tests__/join.spec.ts
+++ b/javascript/core/src/engine/__tests__/join.spec.ts
@@ -3,12 +3,12 @@
  * Licensed under the MIT license. See LICENSE file in the project.
  */
 import type { Step } from '../../types.js'
-import { Verb } from '../../types.js'
+import { Verb, JoinStrategy } from '../../types.js'
 import { join } from '../verbs/join.js'
 import { TestStore } from './TestStore.js'
 
 describe('test for join verb', () => {
-	test('join test', () => {
+	test('inner (default)', () => {
 		const step: Step = {
 			verb: Verb.Join,
 			input: 'table1',
@@ -19,8 +19,61 @@ describe('test for join verb', () => {
 		const store = new TestStore()
 
 		return join(step, store).then(result => {
+			// ID 3 & 5 in the input do not have a match, so will be removed in default inner join
 			expect(result.table.numCols()).toBe(5)
 			expect(result.table.numRows()).toBe(6)
+		})
+	})
+
+	test('left (outer)', () => {
+		const step: Step = {
+			verb: Verb.Join,
+			input: 'table1',
+			output: 'output',
+			args: { other: 'table5', on: ['ID'], strategy: JoinStrategy.Left },
+		}
+
+		const store = new TestStore()
+
+		return join(step, store).then(result => {
+			// ID 3 & 5 in the input do not have a match, but will be preserved with left join
+			expect(result.table.numCols()).toBe(5)
+			expect(result.table.numRows()).toBe(8)
+		})
+	})
+
+	test('right (outer)', () => {
+		const step: Step = {
+			verb: Verb.Join,
+			input: 'table1',
+			output: 'output',
+			args: { other: 'table8', on: ['ID'], strategy: JoinStrategy.Right },
+		}
+
+		const store = new TestStore()
+
+		return join(step, store).then(result => {
+			// ID 6, 7, 8 in the other do not have a match, but will be preserved
+			expect(result.table.numCols()).toBe(5)
+			expect(result.table.numRows()).toBe(5)
+		})
+	})
+
+	test('full (outer)', () => {
+		const step: Step = {
+			verb: Verb.Join,
+			input: 'table1',
+			output: 'output',
+			args: { other: 'table8', on: ['ID'], strategy: JoinStrategy.Full },
+		}
+
+		const store = new TestStore()
+
+		return join(step, store).then(result => {
+			// ID 1, 2, 3 on input and 6, 7, 8 have no matches
+			// but all rows will be preserved in a full outer join
+			expect(result.table.numCols()).toBe(5)
+			expect(result.table.numRows()).toBe(8)
 		})
 	})
 })

--- a/javascript/core/src/engine/__tests__/merge.spec.ts
+++ b/javascript/core/src/engine/__tests__/merge.spec.ts
@@ -84,6 +84,32 @@ describe('test for merge verb', () => {
 				expect(result.table.get('resultColumn', 4)).toBe('stool50')
 			})
 		})
+
+		test('string values with delimiter', () => {
+			const step: Step = {
+				verb: Verb.Merge,
+				input: 'table13',
+				output: 'output',
+				args: {
+					columns: ['name', 'description'],
+					strategy: MergeStrategy.Concat,
+					to: 'resultColumn',
+					delimiter: ',',
+				},
+			}
+
+			const store = new TestStore()
+
+			return merge(step, store).then(result => {
+				expect(result.table.numCols()).toBe(4)
+				expect(result.table.numRows()).toBe(5)
+				expect(result.table.get('resultColumn', 0)).toBe('A,XX')
+				expect(result.table.get('resultColumn', 1)).toBe('B,XT')
+				expect(result.table.get('resultColumn', 2)).toBe('C,QW')
+				expect(result.table.get('resultColumn', 3)).toBe('D,RE')
+				expect(result.table.get('resultColumn', 4)).toBe('E,FG')
+			})
+		})
 	})
 
 	describe('MergeStrategy.FirstOneWins', () => {

--- a/javascript/core/src/engine/__tests__/merge.spec.ts
+++ b/javascript/core/src/engine/__tests__/merge.spec.ts
@@ -9,270 +9,303 @@ import { merge } from '../verbs/merge.js'
 import { TestStore } from './TestStore.js'
 
 describe('test for merge verb', () => {
-	test('merge numeric values and concat strategy', () => {
-		const step: Step = {
-			verb: Verb.Merge,
-			input: 'table12',
-			output: 'output',
-			args: {
-				columns: ['quantity', 'totalSale'],
-				strategy: MergeStrategy.Concat,
-				to: 'resultColumn',
-			},
-		}
+	describe('MergeStrategy.concat', () => {
+		test('numeric values', () => {
+			const step: Step = {
+				verb: Verb.Merge,
+				input: 'table12',
+				output: 'output',
+				args: {
+					columns: ['quantity', 'totalSale'],
+					strategy: MergeStrategy.Concat,
+					to: 'resultColumn',
+				},
+			}
 
-		const store = new TestStore()
+			const store = new TestStore()
 
-		return merge(step, store).then(result => {
-			expect(result.table.numCols()).toBe(5)
-			expect(result.table.numRows()).toBe(5)
-			expect(result.table.get('resultColumn', 0)).toBe('4554000')
-			expect(result.table.get('resultColumn', 1)).toBe('7800')
-			expect(result.table.get('resultColumn', 2)).toBe('100230000')
-			expect(result.table.get('resultColumn', 3)).toBe('8920470')
-			expect(result.table.get('resultColumn', 4)).toBe('505000')
+			return merge(step, store).then(result => {
+				expect(result.table.numCols()).toBe(5)
+				expect(result.table.numRows()).toBe(5)
+				expect(result.table.get('resultColumn', 0)).toBe('4554000')
+				expect(result.table.get('resultColumn', 1)).toBe('7800')
+				expect(result.table.get('resultColumn', 2)).toBe('100230000')
+				expect(result.table.get('resultColumn', 3)).toBe('8920470')
+				expect(result.table.get('resultColumn', 4)).toBe('505000')
+			})
+		})
+
+		test('string values', () => {
+			const step: Step = {
+				verb: Verb.Merge,
+				input: 'table13',
+				output: 'output',
+				args: {
+					columns: ['name', 'description'],
+					strategy: MergeStrategy.Concat,
+					to: 'resultColumn',
+				},
+			}
+
+			const store = new TestStore()
+
+			return merge(step, store).then(result => {
+				expect(result.table.numCols()).toBe(4)
+				expect(result.table.numRows()).toBe(5)
+				expect(result.table.get('resultColumn', 0)).toBe('AXX')
+				expect(result.table.get('resultColumn', 1)).toBe('BXT')
+				expect(result.table.get('resultColumn', 2)).toBe('CQW')
+				expect(result.table.get('resultColumn', 3)).toBe('DRE')
+				expect(result.table.get('resultColumn', 4)).toBe('EFG')
+			})
+		})
+
+		test('numeric and string mixed values', () => {
+			const step: Step = {
+				verb: Verb.Merge,
+				input: 'table12',
+				output: 'output',
+				args: {
+					columns: ['item', 'quantity'],
+					strategy: MergeStrategy.Concat,
+					to: 'resultColumn',
+				},
+			}
+
+			const store = new TestStore()
+
+			return merge(step, store).then(result => {
+				expect(result.table.numCols()).toBe(5)
+				expect(result.table.numRows()).toBe(5)
+				expect(result.table.get('resultColumn', 0)).toBe('bed45')
+				expect(result.table.get('resultColumn', 1)).toBe('pillow')
+				expect(result.table.get('resultColumn', 2)).toBe('100')
+				expect(result.table.get('resultColumn', 3)).toBe('chair89')
+				expect(result.table.get('resultColumn', 4)).toBe('stool50')
+			})
 		})
 	})
 
-	test('merge string values and concat strategy', () => {
-		const step: Step = {
-			verb: Verb.Merge,
-			input: 'table13',
-			output: 'output',
-			args: {
-				columns: ['name', 'description'],
-				strategy: MergeStrategy.Concat,
-				to: 'resultColumn',
-			},
-		}
+	describe('MergeStrategy.FirstOneWins', () => {
+		test('string and numeric mixed values', () => {
+			const step: Step = {
+				verb: Verb.Merge,
+				input: 'table12',
+				output: 'output',
+				args: {
+					columns: ['item', 'quantity'],
+					strategy: MergeStrategy.FirstOneWins,
+					to: 'resultColumn',
+				},
+			}
 
-		const store = new TestStore()
+			const store = new TestStore()
 
-		return merge(step, store).then(result => {
-			expect(result.table.numCols()).toBe(4)
-			expect(result.table.numRows()).toBe(5)
-			expect(result.table.get('resultColumn', 0)).toBe('AXX')
-			expect(result.table.get('resultColumn', 1)).toBe('BXT')
-			expect(result.table.get('resultColumn', 2)).toBe('CQW')
-			expect(result.table.get('resultColumn', 3)).toBe('DRE')
-			expect(result.table.get('resultColumn', 4)).toBe('EFG')
+			return merge(step, store).then(result => {
+				expect(result.table.numCols()).toBe(5)
+				expect(result.table.numRows()).toBe(5)
+				expect(result.table.get('resultColumn', 0)).toBe('bed')
+				expect(result.table.get('resultColumn', 1)).toBe('pillow')
+				expect(result.table.get('resultColumn', 2)).toBe('100')
+				expect(result.table.get('resultColumn', 3)).toBe('chair')
+				expect(result.table.get('resultColumn', 4)).toBe('stool')
+			})
+		})
+
+		test('numeric values', () => {
+			const step: Step = {
+				verb: Verb.Merge,
+				input: 'table12',
+				output: 'output',
+				args: {
+					columns: ['quantity', 'totalSale'],
+					strategy: MergeStrategy.FirstOneWins,
+					to: 'resultColumn',
+				},
+			}
+
+			const store = new TestStore()
+
+			return merge(step, store).then(result => {
+				expect(result.table.numCols()).toBe(5)
+				expect(result.table.numRows()).toBe(5)
+				expect(result.table.get('resultColumn', 0)).toBe(45)
+				expect(result.table.get('resultColumn', 1)).toBe(7800)
+				expect(result.table.get('resultColumn', 2)).toBe(100)
+				expect(result.table.get('resultColumn', 3)).toBe(89)
+				expect(result.table.get('resultColumn', 4)).toBe(50)
+			})
+		})
+
+		test('boolean and string mixed values', () => {
+			const step: Step = {
+				verb: Verb.Merge,
+				input: 'table14',
+				output: 'output',
+				args: {
+					columns: ['y', 'z'],
+					strategy: MergeStrategy.FirstOneWins,
+					to: 'resultColumn',
+				},
+			}
+
+			const store = new TestStore()
+
+			return merge(step, store).then(result => {
+				expect(result.table.numCols()).toBe(4)
+				expect(result.table.numRows()).toBe(3)
+				expect(result.table.get('resultColumn', 0)).toBe('1')
+				expect(result.table.get('resultColumn', 1)).toBe('false')
+				expect(result.table.get('resultColumn', 2)).toBe('1')
+			})
+		})
+
+		test('boolean values', () => {
+			const step: Step = {
+				verb: Verb.Merge,
+				input: 'table15',
+				output: 'output',
+				args: {
+					columns: ['y', 'z'],
+					strategy: MergeStrategy.FirstOneWins,
+					to: 'resultColumn',
+				},
+			}
+
+			const store = new TestStore()
+
+			return merge(step, store).then(result => {
+				expect(result.table.numCols()).toBe(4)
+				expect(result.table.numRows()).toBe(3)
+				expect(result.table.get('resultColumn', 0)).toBe(true)
+				expect(result.table.get('resultColumn', 1)).toBe(true)
+				expect(result.table.get('resultColumn', 2)).toBe(false)
+			})
 		})
 	})
 
-	test('merge numeric and string values and concat strategy', () => {
-		const step: Step = {
-			verb: Verb.Merge,
-			input: 'table12',
-			output: 'output',
-			args: {
-				columns: ['item', 'quantity'],
-				strategy: MergeStrategy.Concat,
-				to: 'resultColumn',
-			},
-		}
+	describe('MergeStrategy.LastOneWins', () => {
+		test('string and numeric mixed values', () => {
+			const step: Step = {
+				verb: Verb.Merge,
+				input: 'table12',
+				output: 'output',
+				args: {
+					columns: ['item', 'quantity'],
+					strategy: MergeStrategy.LastOneWins,
+					to: 'resultColumn',
+				},
+			}
 
-		const store = new TestStore()
+			const store = new TestStore()
 
-		return merge(step, store).then(result => {
-			expect(result.table.numCols()).toBe(5)
-			expect(result.table.numRows()).toBe(5)
-			expect(result.table.get('resultColumn', 0)).toBe('bed45')
-			expect(result.table.get('resultColumn', 1)).toBe('pillow')
-			expect(result.table.get('resultColumn', 2)).toBe('100')
-			expect(result.table.get('resultColumn', 3)).toBe('chair89')
-			expect(result.table.get('resultColumn', 4)).toBe('stool50')
+			return merge(step, store).then(result => {
+				expect(result.table.numCols()).toBe(5)
+				expect(result.table.numRows()).toBe(5)
+				expect(result.table.get('resultColumn', 0)).toBe('45')
+				expect(result.table.get('resultColumn', 1)).toBe('pillow')
+				expect(result.table.get('resultColumn', 2)).toBe('100')
+				expect(result.table.get('resultColumn', 3)).toBe('89')
+				expect(result.table.get('resultColumn', 4)).toBe('50')
+			})
+		})
+
+		test('numeric values', () => {
+			const step: Step = {
+				verb: Verb.Merge,
+				input: 'table12',
+				output: 'output',
+				args: {
+					columns: ['quantity', 'totalSale'],
+					strategy: MergeStrategy.LastOneWins,
+					to: 'resultColumn',
+				},
+			}
+
+			const store = new TestStore()
+
+			return merge(step, store).then(result => {
+				expect(result.table.numCols()).toBe(5)
+				expect(result.table.numRows()).toBe(5)
+				expect(result.table.get('resultColumn', 0)).toBe(54000)
+				expect(result.table.get('resultColumn', 1)).toBe(7800)
+				expect(result.table.get('resultColumn', 2)).toBe(230000)
+				expect(result.table.get('resultColumn', 3)).toBe(20470)
+				expect(result.table.get('resultColumn', 4)).toBe(5000)
+			})
+		})
+
+		test('boolean and string mixed values', () => {
+			const step: Step = {
+				verb: Verb.Merge,
+				input: 'table14',
+				output: 'output',
+				args: {
+					columns: ['y', 'z'],
+					strategy: MergeStrategy.LastOneWins,
+					to: 'resultColumn',
+				},
+			}
+
+			const store = new TestStore()
+
+			return merge(step, store).then(result => {
+				expect(result.table.numCols()).toBe(4)
+				expect(result.table.numRows()).toBe(3)
+				expect(result.table.get('resultColumn', 0)).toBe('true')
+				expect(result.table.get('resultColumn', 1)).toBe('false')
+				expect(result.table.get('resultColumn', 2)).toBe('false')
+			})
+		})
+
+		test('boolean values', () => {
+			const step: Step = {
+				verb: Verb.Merge,
+				input: 'table15',
+				output: 'output',
+				args: {
+					columns: ['y', 'z'],
+					strategy: MergeStrategy.LastOneWins,
+					to: 'resultColumn',
+				},
+			}
+
+			const store = new TestStore()
+
+			return merge(step, store).then(result => {
+				expect(result.table.numCols()).toBe(4)
+				expect(result.table.numRows()).toBe(3)
+				expect(result.table.get('resultColumn', 0)).toBe(true)
+				expect(result.table.get('resultColumn', 1)).toBe(false)
+				expect(result.table.get('resultColumn', 2)).toBe(true)
+			})
 		})
 	})
 
-	test('merge with string and numeric values - different datatype values - first one wins strategy', () => {
-		const step: Step = {
-			verb: Verb.Merge,
-			input: 'table12',
-			output: 'output',
-			args: {
-				columns: ['item', 'quantity'],
-				strategy: MergeStrategy.FirstOneWins,
-				to: 'resultColumn',
-			},
-		}
+	describe('MergeStrategy.array', () => {
+		test('numeric values', () => {
+			const step: Step = {
+				verb: Verb.Merge,
+				input: 'table12',
+				output: 'output',
+				args: {
+					columns: ['quantity', 'totalSale'],
+					strategy: MergeStrategy.Array,
+					to: 'resultColumn',
+				},
+			}
 
-		const store = new TestStore()
+			const store = new TestStore()
 
-		return merge(step, store).then(result => {
-			expect(result.table.numCols()).toBe(5)
-			expect(result.table.numRows()).toBe(5)
-			expect(result.table.get('resultColumn', 0)).toBe('bed')
-			expect(result.table.get('resultColumn', 1)).toBe('pillow')
-			expect(result.table.get('resultColumn', 2)).toBe('100')
-			expect(result.table.get('resultColumn', 3)).toBe('chair')
-			expect(result.table.get('resultColumn', 4)).toBe('stool')
-		})
-	})
-
-	test('merge with numeric values - same datatype values - first one wins strategy', () => {
-		const step: Step = {
-			verb: Verb.Merge,
-			input: 'table12',
-			output: 'output',
-			args: {
-				columns: ['quantity', 'totalSale'],
-				strategy: MergeStrategy.FirstOneWins,
-				to: 'resultColumn',
-			},
-		}
-
-		const store = new TestStore()
-
-		return merge(step, store).then(result => {
-			expect(result.table.numCols()).toBe(5)
-			expect(result.table.numRows()).toBe(5)
-			expect(result.table.get('resultColumn', 0)).toBe(45)
-			expect(result.table.get('resultColumn', 1)).toBe(7800)
-			expect(result.table.get('resultColumn', 2)).toBe(100)
-			expect(result.table.get('resultColumn', 3)).toBe(89)
-			expect(result.table.get('resultColumn', 4)).toBe(50)
-		})
-	})
-
-	test('merge with boolean and string values - different datatype values - first one wins strategy', () => {
-		const step: Step = {
-			verb: Verb.Merge,
-			input: 'table14',
-			output: 'output',
-			args: {
-				columns: ['y', 'z'],
-				strategy: MergeStrategy.FirstOneWins,
-				to: 'resultColumn',
-			},
-		}
-
-		const store = new TestStore()
-
-		return merge(step, store).then(result => {
-			expect(result.table.numCols()).toBe(4)
-			expect(result.table.numRows()).toBe(3)
-			expect(result.table.get('resultColumn', 0)).toBe('1')
-			expect(result.table.get('resultColumn', 1)).toBe('false')
-			expect(result.table.get('resultColumn', 2)).toBe('1')
-		})
-	})
-
-	test('merge with boolean values - same datatype values - first one wins strategy', () => {
-		const step: Step = {
-			verb: Verb.Merge,
-			input: 'table15',
-			output: 'output',
-			args: {
-				columns: ['y', 'z'],
-				strategy: MergeStrategy.FirstOneWins,
-				to: 'resultColumn',
-			},
-		}
-
-		const store = new TestStore()
-
-		return merge(step, store).then(result => {
-			expect(result.table.numCols()).toBe(4)
-			expect(result.table.numRows()).toBe(3)
-			expect(result.table.get('resultColumn', 0)).toBe(true)
-			expect(result.table.get('resultColumn', 1)).toBe(true)
-			expect(result.table.get('resultColumn', 2)).toBe(false)
-		})
-	})
-
-	test('merge with string and numeric values - different datatype values - last one wins strategy', () => {
-		const step: Step = {
-			verb: Verb.Merge,
-			input: 'table12',
-			output: 'output',
-			args: {
-				columns: ['item', 'quantity'],
-				strategy: MergeStrategy.LastOneWins,
-				to: 'resultColumn',
-			},
-		}
-
-		const store = new TestStore()
-
-		return merge(step, store).then(result => {
-			expect(result.table.numCols()).toBe(5)
-			expect(result.table.numRows()).toBe(5)
-			expect(result.table.get('resultColumn', 0)).toBe('45')
-			expect(result.table.get('resultColumn', 1)).toBe('pillow')
-			expect(result.table.get('resultColumn', 2)).toBe('100')
-			expect(result.table.get('resultColumn', 3)).toBe('89')
-			expect(result.table.get('resultColumn', 4)).toBe('50')
-		})
-	})
-
-	test('merge with numeric values - same datatype values - last one wins strategy', () => {
-		const step: Step = {
-			verb: Verb.Merge,
-			input: 'table12',
-			output: 'output',
-			args: {
-				columns: ['quantity', 'totalSale'],
-				strategy: MergeStrategy.LastOneWins,
-				to: 'resultColumn',
-			},
-		}
-
-		const store = new TestStore()
-
-		return merge(step, store).then(result => {
-			expect(result.table.numCols()).toBe(5)
-			expect(result.table.numRows()).toBe(5)
-			expect(result.table.get('resultColumn', 0)).toBe(54000)
-			expect(result.table.get('resultColumn', 1)).toBe(7800)
-			expect(result.table.get('resultColumn', 2)).toBe(230000)
-			expect(result.table.get('resultColumn', 3)).toBe(20470)
-			expect(result.table.get('resultColumn', 4)).toBe(5000)
-		})
-	})
-
-	test('merge with boolean and string values - different datatype values - last one wins strategy', () => {
-		const step: Step = {
-			verb: Verb.Merge,
-			input: 'table14',
-			output: 'output',
-			args: {
-				columns: ['y', 'z'],
-				strategy: MergeStrategy.LastOneWins,
-				to: 'resultColumn',
-			},
-		}
-
-		const store = new TestStore()
-
-		return merge(step, store).then(result => {
-			expect(result.table.numCols()).toBe(4)
-			expect(result.table.numRows()).toBe(3)
-			expect(result.table.get('resultColumn', 0)).toBe('true')
-			expect(result.table.get('resultColumn', 1)).toBe('false')
-			expect(result.table.get('resultColumn', 2)).toBe('false')
-		})
-	})
-
-	test('merge with boolean values - same datatype values - last one wins strategy', () => {
-		const step: Step = {
-			verb: Verb.Merge,
-			input: 'table15',
-			output: 'output',
-			args: {
-				columns: ['y', 'z'],
-				strategy: MergeStrategy.LastOneWins,
-				to: 'resultColumn',
-			},
-		}
-
-		const store = new TestStore()
-
-		return merge(step, store).then(result => {
-			expect(result.table.numCols()).toBe(4)
-			expect(result.table.numRows()).toBe(3)
-			expect(result.table.get('resultColumn', 0)).toBe(true)
-			expect(result.table.get('resultColumn', 1)).toBe(false)
-			expect(result.table.get('resultColumn', 2)).toBe(true)
+			return merge(step, store).then(result => {
+				expect(result.table.numCols()).toBe(5)
+				expect(result.table.numRows()).toBe(5)
+				expect(result.table.get('resultColumn', 0)).toEqual([45, 54000])
+				expect(result.table.get('resultColumn', 1)).toEqual([7800])
+				expect(result.table.get('resultColumn', 2)).toEqual([100, 230000])
+				expect(result.table.get('resultColumn', 3)).toEqual([89, 20470])
+				expect(result.table.get('resultColumn', 4)).toEqual([50, 5000])
+			})
 		})
 	})
 })

--- a/javascript/core/src/engine/verbs/index.ts
+++ b/javascript/core/src/engine/verbs/index.ts
@@ -4,7 +4,7 @@
  */
 import { BinStrategy } from '../../index.js'
 import type { Step } from '../../types.js'
-import { FieldAggregateOperation, Verb } from '../../types.js'
+import { JoinStrategy, FieldAggregateOperation, Verb } from '../../types.js'
 
 /**
  * Factory function to create new verb configs
@@ -93,9 +93,15 @@ export function factory(verb: Verb, input: string, output: string): Step {
 					operation: FieldAggregateOperation.Any,
 				},
 			}
+		case Verb.Join:
+			return {
+				...base,
+				args: {
+					strategy: JoinStrategy.Inner,
+				},
+			}
 		case Verb.Fetch:
 		case Verb.Filter:
-		case Verb.Join:
 		case Verb.Orderby:
 		case Verb.Rename:
 		case Verb.Sample:

--- a/javascript/core/src/engine/verbs/index.ts
+++ b/javascript/core/src/engine/verbs/index.ts
@@ -41,6 +41,7 @@ export function factory(verb: Verb, input: string, output: string): Step {
 		case Verb.Derive:
 		case Verb.Impute:
 		case Verb.Fill:
+		case Verb.Merge:
 		case Verb.Rollup:
 		case Verb.Window:
 			return {
@@ -101,7 +102,6 @@ export function factory(verb: Verb, input: string, output: string): Step {
 		case Verb.Ungroup:
 		case Verb.Unorder:
 		case Verb.Erase:
-		case Verb.Merge:
 		case Verb.Unfold:
 	}
 	return {

--- a/javascript/core/src/engine/verbs/join.ts
+++ b/javascript/core/src/engine/verbs/join.ts
@@ -2,9 +2,11 @@
  * Copyright (c) Microsoft. All rights reserved.
  * Licensed under the MIT license. See LICENSE file in the project.
  */
+import type { JoinOptions } from 'arquero/dist/types/table/transformable'
 import { container } from '../../factories.js'
 import type { TableStore } from '../../index.js'
 import type { JoinArgs, Step, TableContainer } from '../../types.js'
+import { JoinStrategy } from '../../types.js'
 
 /**
  * Executes an arquero join.
@@ -17,10 +19,16 @@ export async function join(
 	store: TableStore,
 ): Promise<TableContainer> {
 	const { input, output, args } = step
-	const { other, on } = args as JoinArgs
+	const { other, on, strategy = JoinStrategy.Inner } = args as JoinArgs
 	const [inputTable, otherTable] = await Promise.all([
 		store.table(input),
 		store.table(other),
 	])
-	return container(output, inputTable.join(otherTable, on))
+
+	const options: JoinOptions = {
+		left: strategy === JoinStrategy.Left || strategy === JoinStrategy.Full,
+		right: strategy === JoinStrategy.Right || strategy === JoinStrategy.Full,
+	}
+
+	return container(output, inputTable.join(otherTable, on, undefined, options))
 }

--- a/javascript/core/src/types/enums.ts
+++ b/javascript/core/src/types/enums.ts
@@ -148,3 +148,10 @@ export enum BinStrategy {
 	FixedCount = 'fixed count',
 	FixedWidth = 'fixed width',
 }
+
+export enum JoinStrategy {
+	Inner = 'inner',
+	Left = 'join_left',
+	Right = 'join_right',
+	Full = 'join_full',
+}

--- a/javascript/core/src/types/enums.ts
+++ b/javascript/core/src/types/enums.ts
@@ -42,6 +42,7 @@ export enum MergeStrategy {
 	FirstOneWins = 'first one wins',
 	LastOneWins = 'last one wins',
 	Concat = 'concat',
+	Array = 'array',
 }
 
 export enum DataType {

--- a/javascript/core/src/types/steps.ts
+++ b/javascript/core/src/types/steps.ts
@@ -285,6 +285,11 @@ export interface SpreadArgs {
 
 export interface MergeArgs extends InputColumnListArgs, OutputColumnArgs {
 	strategy: MergeStrategy
+	/**
+	 * This is only necessary if mergeStrategy.Concat is used.
+	 * If it is not supplied, the values are just mashed together.
+	 */
+	delimiter?: string
 }
 
 export interface OrderbyArgs {

--- a/javascript/core/src/types/steps.ts
+++ b/javascript/core/src/types/steps.ts
@@ -7,6 +7,7 @@ import type {
 	BinStrategy,
 	FieldAggregateOperation,
 	FilterCompareType,
+	JoinStrategy,
 	MathOperator,
 	MergeStrategy,
 	NumericComparisonOperator,
@@ -230,7 +231,7 @@ export interface ImputeArgs extends InputColumnArgs {
 	value: Value
 }
 
-export interface JoinArgs {
+export interface JoinArgsBase {
 	/**
 	 * Name of the other table to join to the main input
 	 */
@@ -243,7 +244,11 @@ export interface JoinArgs {
 	on?: string[]
 }
 
-export interface LookupArgs extends JoinArgs, InputColumnListArgs {}
+export interface JoinArgs extends JoinArgsBase {
+	strategy?: JoinStrategy
+}
+
+export interface LookupArgs extends JoinArgsBase, InputColumnListArgs {}
 
 export interface RecodeArgs extends InputColumnArgs, OutputColumnArgs {
 	/**

--- a/javascript/guidance/package.json
+++ b/javascript/guidance/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@data-wrangling-components/guidance",
-	"version": "0.1.2",
+	"version": "0.1.3",
 	"type": "module",
 	"main": "dist/index.js",
 	"publishConfig": {

--- a/javascript/react/src/Steps/ManageSteps/ManageSteps.tsx
+++ b/javascript/react/src/Steps/ManageSteps/ManageSteps.tsx
@@ -55,8 +55,10 @@ export const ManageSteps: React.FC<ManageStepsProps> = memo(
 			onEditClicked,
 			onCreate,
 			onDismissTransformModal,
-			showTransformModal,
-			isTansformModalOpen,
+			onStartNewStep,
+			isTransformModalOpen,
+			addStepButtonId,
+			editorTarget,
 		} = useManageSteps(type, store, table, onSave)
 
 		return (
@@ -67,15 +69,17 @@ export const ManageSteps: React.FC<ManageStepsProps> = memo(
 					onEditClicked={onEditClicked}
 					steps={steps}
 					onDuplicateClicked={onDuplicateClicked}
-					showModal={showTransformModal}
+					onStartNewStep={onStartNewStep}
+					buttonId={addStepButtonId}
 				/>
 
 				<div>
-					{type === StepsType.Table && (
+					{type === StepsType.Table && isTransformModalOpen && (
 						<TableTransformModal
+							target={editorTarget}
 							step={step}
 							onTransformRequested={onCreate}
-							isOpen={isTansformModalOpen}
+							isOpen={isTransformModalOpen}
 							store={store}
 							onDismiss={onDismissTransformModal}
 							{...rest}
@@ -87,7 +91,7 @@ export const ManageSteps: React.FC<ManageStepsProps> = memo(
 							step={step}
 							table={table}
 							onTransformRequested={onCreate}
-							isOpen={isTansformModalOpen}
+							isOpen={isTransformModalOpen}
 							onDismiss={onDismissTransformModal}
 							{...rest}
 						/>

--- a/javascript/react/src/Steps/ManageSteps/hooks/useManageSteps.tsx
+++ b/javascript/react/src/Steps/ManageSteps/hooks/useManageSteps.tsx
@@ -6,7 +6,7 @@
 import type { Step, TableStore } from '@data-wrangling-components/core'
 import { useBoolean } from '@fluentui/react-hooks'
 import type ColumnTable from 'arquero/dist/types/table/column-table'
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useMemo, useEffect } from 'react'
 import type { StepsType } from '../../../index.js'
 import { useOnDuplicateStep, useOnEditStep } from './index.js'
 
@@ -21,13 +21,16 @@ export function useManageSteps(
 	onDuplicateClicked: (step: Step) => void
 	onEditClicked: (step: Step, index: number) => void
 	onCreate: (step: Step, index?: number) => void
-	showTransformModal: () => void
-	isTansformModalOpen: boolean
+	onStartNewStep: () => void
+	isTransformModalOpen: boolean
+	addStepButtonId: string
+	editorTarget?: string
 } {
 	const [step, setStep] = useState<Step>()
 	const [stepIndex, setStepIndex] = useState<number>()
+
 	const [
-		isTansformModalOpen,
+		isTransformModalOpen,
 		{ setTrue: showTransformModal, setFalse: hideTransformModal },
 	] = useBoolean(false)
 
@@ -48,13 +51,33 @@ export function useManageSteps(
 	)
 	const onDuplicateClicked = useOnDuplicateStep(type, store, table, onSave)
 
+	const addStepButtonId = useMemo(
+		() => `button-${Math.round(Math.random() * 3)}`,
+		[],
+	)
+
+	const [editorTarget, setEditorTarget] = useState<string>(addStepButtonId)
+	useEffect(() => {
+		if (stepIndex !== undefined) {
+			setEditorTarget(`.step-card-${stepIndex}`)
+		} else {
+			setEditorTarget(`#${addStepButtonId}`)
+		}
+	}, [addStepButtonId, stepIndex])
+
+	const onStartNewStep = useCallback(() => {
+		showTransformModal()
+	}, [showTransformModal])
+
 	return {
 		step,
 		onDuplicateClicked,
 		onDismissTransformModal,
 		onEditClicked,
 		onCreate,
-		isTansformModalOpen,
-		showTransformModal,
+		isTransformModalOpen,
+		onStartNewStep,
+		addStepButtonId,
+		editorTarget,
 	}
 }

--- a/javascript/react/src/Steps/StepCard/StepCard.tsx
+++ b/javascript/react/src/Steps/StepCard/StepCard.tsx
@@ -39,7 +39,11 @@ export const StepCard: React.FC<{
 			<CardContent>
 				<Description step={step} showInput showOutput />
 			</CardContent>
-			<DocumentCardActions styles={styles.actions} actions={stepActions} />
+			<DocumentCardActions
+				className={`step-card-${index}`}
+				styles={styles.actions}
+				actions={stepActions}
+			/>
 		</Card>
 	)
 })

--- a/javascript/react/src/Steps/StepsList/StepsList.tsx
+++ b/javascript/react/src/Steps/StepsList/StepsList.tsx
@@ -15,14 +15,16 @@ export const StepsList: React.FC<{
 	onEditClicked?: (step: Step, index: number) => void
 	onDuplicateClicked?: (step: Step) => void
 	onSelect?: (name: string) => void
-	showModal?: () => void
+	onStartNewStep?: () => void
+	buttonId?: string
 }> = memo(function StepsList({
 	steps,
 	onDeleteClicked,
 	onEditClicked,
 	onDuplicateClicked,
 	onSelect,
-	showModal,
+	onStartNewStep,
+	buttonId,
 }) {
 	return (
 		<Container>
@@ -40,12 +42,13 @@ export const StepsList: React.FC<{
 				)
 			})}
 
-			{showModal && (
+			{onStartNewStep && (
 				<ButtonContainer>
 					<DefaultButton
 						styles={addButtonStyles}
 						iconProps={iconProps.add}
-						onClick={showModal}
+						onClick={onStartNewStep}
+						id={buttonId}
 					>
 						Add step
 					</DefaultButton>

--- a/javascript/react/src/TableTransformModal/TableTransformModal.tsx
+++ b/javascript/react/src/TableTransformModal/TableTransformModal.tsx
@@ -4,7 +4,12 @@
  */
 import type { TableStore } from '@data-wrangling-components/core'
 import index from '@data-wrangling-components/guidance'
-import { IconButton, Modal, PrimaryButton } from '@fluentui/react'
+import {
+	Callout,
+	DirectionalHint,
+	IconButton,
+	PrimaryButton,
+} from '@fluentui/react'
 import { useBoolean } from '@fluentui/react-hooks'
 import React, { memo } from 'react'
 import styled from 'styled-components'
@@ -46,10 +51,10 @@ export const TableTransformModal: React.FC<TableTransformModalProps> = memo(
 
 		const adaptedStyles = useModalStyles(styles, isGuidanceVisible)
 		return (
-			<Modal
-				onDismiss={onDismiss}
+			<Callout
 				onDismissed={() => setInternal(undefined)}
 				styles={adaptedStyles}
+				directionalHint={DirectionalHint.rightTopEdge}
 				{...rest}
 			>
 				<Header>
@@ -99,7 +104,7 @@ export const TableTransformModal: React.FC<TableTransformModalProps> = memo(
 						/>
 					) : null}
 				</ContainerBody>
-			</Modal>
+			</Callout>
 		)
 	},
 )

--- a/javascript/react/src/VerbDescription/VerbDescription.tsx
+++ b/javascript/react/src/VerbDescription/VerbDescription.tsx
@@ -96,5 +96,6 @@ const Value = styled.div`
 	max-width: 240px;
 	text-overflow: ellipsis;
 	overflow: hidden;
-	color: ${({ theme }) => theme.application().accent().hex()};
+	font-weight: bold;
+	color: ${({ theme }) => theme.application().midContrast().hex()};
 `

--- a/javascript/react/src/common/styles.ts
+++ b/javascript/react/src/common/styles.ts
@@ -34,3 +34,11 @@ export const LeftAlignedRow = styled.div`
 	align-items: flex-end;
 	margin-bottom: 8px;
 `
+
+/**
+ * For explanatory text below an input,
+ */
+export const InputExplainer = styled.div`
+	font-size: 0.85em;
+	color: ${({ theme }) => theme.application().midHighContrast().hex()};
+`

--- a/javascript/react/src/controls/dropdowns/JoinStrategyDropdown.tsx
+++ b/javascript/react/src/controls/dropdowns/JoinStrategyDropdown.tsx
@@ -1,0 +1,33 @@
+/*!
+ * Copyright (c) Microsoft. All rights reserved.
+ * Licensed under the MIT license. See LICENSE file in the project.
+ */
+import { JoinStrategy } from '@data-wrangling-components/core'
+import type { IDropdownProps } from '@fluentui/react'
+import { Dropdown } from '@fluentui/react'
+import { memo } from 'react'
+import { opDropdownStyles } from '../styles.js'
+
+export type JoinStrategyDropdownProps = Partial<IDropdownProps>
+
+/**
+ * Dropdown wrapper to list out math operations.
+ */
+export const JoinStrategyDropdown: React.FC<JoinStrategyDropdownProps> = memo(
+	function JoinStrategyDropdown(props) {
+		return (
+			<Dropdown
+				required
+				label={'Join strategy'}
+				options={options}
+				styles={opDropdownStyles}
+				{...props}
+			/>
+		)
+	},
+)
+
+const options = Object.values(JoinStrategy).map(o => ({
+	key: o,
+	text: o,
+}))

--- a/javascript/react/src/types.ts
+++ b/javascript/react/src/types.ts
@@ -43,6 +43,7 @@ export interface TransformModalProps extends IModalProps {
 	 *  or as input for table transform
 	 */
 	nextInputTable?: string
+	target?: string
 }
 
 export interface TableTransformModalProps extends TransformModalProps {

--- a/javascript/react/src/verbs/Join/Join.tsx
+++ b/javascript/react/src/verbs/Join/Join.tsx
@@ -2,18 +2,52 @@
  * Copyright (c) Microsoft. All rights reserved.
  * Licensed under the MIT license. See LICENSE file in the project.
  */
-import { memo } from 'react'
+import type { JoinStep } from '@data-wrangling-components/core'
+import { memo, useMemo } from 'react'
+import styled from 'styled-components'
+import { useHandleDropdownChange } from '../../common/hooks.js'
+import { LeftAlignedColumn } from '../../common/index.js'
+import { JoinStrategyDropdown } from '../../controls/dropdowns/JoinStrategyDropdown.js'
+import { dropdownStyles } from '../../controls/styles.js'
 import type { StepComponentProps } from '../../types.js'
 import { JoinInputs } from '../shared/index.js'
 
 /**
  * Provides inputs for a Join step.
- * TODO: join and lookup are essentially the same inputs
- * the difference is that lookup requires the copy columns
- * whereas join defaults to copying all
- * however, arquero join does support lookup columns on join,
- * so we could add it as optional inputs
  */
-export const Join: React.FC<StepComponentProps> = memo(function Join(props) {
-	return <JoinInputs {...props} />
+export const Join: React.FC<StepComponentProps> = memo(function Join({
+	step,
+	store,
+	table,
+	onChange,
+}) {
+	const internal = useMemo(() => step as JoinStep, [step])
+
+	const handleJoinStrategyChange = useHandleDropdownChange(
+		internal,
+		'args.strategy',
+		onChange,
+	)
+
+	return (
+		<Container>
+			<JoinInputs step={step} store={store} table={table} onChange={onChange} />
+			<LeftAlignedColumn>
+				<JoinStrategyDropdown
+					required
+					selectedKey={internal.args.strategy}
+					styles={dropdownStyles}
+					onChange={handleJoinStrategyChange}
+				/>
+			</LeftAlignedColumn>
+		</Container>
+	)
 })
+
+const Container = styled.div`
+	display: flex;
+	justify-content: flex-start;
+	flex-wrap: wrap;
+	align-content: flex-start;
+	flex-direction: column;
+`

--- a/javascript/react/src/verbs/Merge/Merge.tsx
+++ b/javascript/react/src/verbs/Merge/Merge.tsx
@@ -3,11 +3,16 @@
  * Licensed under the MIT license. See LICENSE file in the project.
  */
 import type { MergeStep } from '@data-wrangling-components/core'
+import { MergeStrategy } from '@data-wrangling-components/core'
 import type { IDropdownOption } from '@fluentui/react'
-import { Dropdown } from '@fluentui/react'
+import { TextField, Dropdown } from '@fluentui/react'
 import { memo, useCallback, useMemo } from 'react'
 import styled from 'styled-components'
-import { LeftAlignedRow, useLoadTable } from '../../common'
+import {
+	LeftAlignedRow,
+	useHandleTextfieldChange,
+	useLoadTable,
+} from '../../common'
 import { MergeStrategyComponent } from '../../controls/MergeStrategyComponent/MergeStrategyComponent.js'
 import { dropdownStyles } from '../../controls/styles'
 import type { StepComponentProps } from '../../types'
@@ -47,6 +52,12 @@ export const Merge: React.FC<StepComponentProps> = memo(function Merge({
 				})
 		},
 		[internal, onChange],
+	)
+
+	const handleDelimiterChange = useHandleTextfieldChange(
+		internal,
+		'args.delimiter',
+		onChange,
 	)
 
 	const options = useMemo(() => {
@@ -93,6 +104,17 @@ export const Merge: React.FC<StepComponentProps> = memo(function Merge({
 					onChange={onChange}
 				/>
 			</LeftAlignedRow>
+			{internal.args.strategy === MergeStrategy.Concat ? (
+				<LeftAlignedRow>
+					<TextField
+						label={'Delimiter'}
+						placeholder={'Text delimiter'}
+						value={internal.args.delimiter && `${internal.args.delimiter}`}
+						styles={dropdownStyles}
+						onChange={handleDelimiterChange}
+					/>
+				</LeftAlignedRow>
+			) : null}
 		</Container>
 	)
 })

--- a/javascript/react/src/verbs/shared/FilterFunction/FilterFunction.tsx
+++ b/javascript/react/src/verbs/shared/FilterFunction/FilterFunction.tsx
@@ -12,6 +12,7 @@ import set from 'lodash-es/set.js'
 import { memo, useCallback, useMemo } from 'react'
 import styled from 'styled-components'
 import { useLoadTable, useHandleDropdownChange } from '../../../common/index.js'
+import { InputExplainer } from '../../../common/styles.js'
 import {
 	ColumnOrValueComboBox,
 	NumericComparisonOperatorDropdown,
@@ -51,6 +52,7 @@ export const FilterFunction: React.FC<StepComponentProps> = memo(
 			[internal, onChange],
 		)
 
+		// TODO: use the types util
 		const operatorDropdown = useMemo(() => {
 			const column = internal.args.column
 			if (column) {
@@ -58,10 +60,15 @@ export const FilterFunction: React.FC<StepComponentProps> = memo(
 				if (first) {
 					if (typeof first === 'string') {
 						return (
-							<StringComparisonOperatorDropdown
-								selectedKey={internal.args.operator}
-								onChange={handleOpChange}
-							/>
+							<DropdownContainer>
+								<StringComparisonOperatorDropdown
+									selectedKey={internal.args.operator}
+									onChange={handleOpChange}
+								/>
+								<InputExplainer>
+									String comparisons not case-sensitive
+								</InputExplainer>
+							</DropdownContainer>
 						)
 					}
 				}
@@ -103,6 +110,11 @@ export const FilterFunction: React.FC<StepComponentProps> = memo(
 )
 
 const Container = styled.div`
+	display: flex;
+	flex-direction: column;
+`
+
+const DropdownContainer = styled.div`
 	display: flex;
 	flex-direction: column;
 `


### PR DESCRIPTION
- Adds case sensitivity note to string compare inputs
- Adds new merge option for concat delimiter or array strategy
- Changes visual of step params to not look like hyperlinks
- Updated binarize logic to set invalid comparisons to 0
- Makes step editor a Callout and pins it to the button or card
- Adds additional join options (inner is default, left, right, outer)