### PR TITLE
Table polish

### DIFF
--- a/.yarn/versions/73bde51c.yml
+++ b/.yarn/versions/73bde51c.yml
@@ -1,0 +1,4 @@
+releases:
+  "@data-wrangling-components/core": patch
+  "@data-wrangling-components/react": patch
+  "@data-wrangling-components/webapp": patch

--- a/javascript/core/src/engine/runPipeline.ts
+++ b/javascript/core/src/engine/runPipeline.ts
@@ -25,7 +25,6 @@ export async function runPipeline(
 
 	// make sure each step has an input/output
 	// if missing we'll just chain them sequentially
-	// TODO: do this recusively for compound steps as well
 	const internal = (isArray(steps) ? steps : [steps]).map((step, idx, arr) => {
 		const copy = {
 			...step,

--- a/javascript/core/src/engine/verbs/fill.ts
+++ b/javascript/core/src/engine/verbs/fill.ts
@@ -12,8 +12,6 @@ import type { ExprFunctionMap } from './types.js'
  * Executes an arquero derive to fill a new column with fixed values.
  * Note this is not the same as imputing, which fills missing values.
  * This is intended to create an entirely new column.
- * TODO: fill with function outputs such as op.row_number or a column copy.
- * This could be merged with derive eventually.
  * @param step
  * @param store
  * @returns

--- a/javascript/react/docs/react.api.md
+++ b/javascript/react/docs/react.api.md
@@ -120,8 +120,6 @@ export interface ArqueroTableHeaderProps {
     table: ColumnTable;
     // (undocumented)
     visibleColumns?: string[];
-    // (undocumented)
-    visibleRows?: number;
 }
 
 // Warning: (ae-missing-release-tag) "Bin" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/javascript/react/src/ArqueroDetailsList/renderers/ArrayCell.tsx
+++ b/javascript/react/src/ArqueroDetailsList/renderers/ArrayCell.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) Microsoft. All rights reserved.
  * Licensed under the MIT license. See LICENSE file in the project.
  */
-import { memo } from 'react'
+import { memo, useMemo } from 'react'
 
 import { getValue } from '../util/index.js'
 import type { FormattedCellProps } from './types.js'
@@ -19,10 +19,11 @@ export const ArrayCell: React.FC<FormattedCellProps> = memo(function ArrayCell({
 	textAlign = 'left',
 }) {
 	const values = getValue(item, column) || []
-	const printed = values.slice(0, CELL_LENGTH).join(', ')
+	const printed = usePrinted(values)
+	const tooltip = useTooltip(values)
 	return (
 		<div
-			title={tooltip(values, TOOLTIP_LENGTH)}
+			title={tooltip}
 			style={{
 				textAlign,
 			}}
@@ -32,10 +33,19 @@ export const ArrayCell: React.FC<FormattedCellProps> = memo(function ArrayCell({
 	)
 })
 
-function tooltip(values: any[], length: number) {
-	let tooltip = values.slice(0, length).join('\n')
-	if (values.length > length) {
-		tooltip += `\n...\n(+${values.length - length} more)`
-	}
-	return tooltip
+function usePrinted(values: unknown[], length = CELL_LENGTH) {
+	return useMemo(() => {
+		const arr = `[${values.slice(0, length).join(', ')}]`
+		return values.length > length ? `${arr}...` : arr
+	}, [values, length])
+}
+
+function useTooltip(values: unknown[], length = TOOLTIP_LENGTH) {
+	return useMemo(() => {
+		let tooltip = values.slice(0, length).join('\n')
+		if (values.length > length) {
+			tooltip += `\n...\n(+${values.length - length} more)`
+		}
+		return tooltip
+	}, [values, length])
 }

--- a/javascript/react/src/ArqueroDetailsList/renderers/BooleanSymbolCell.tsx
+++ b/javascript/react/src/ArqueroDetailsList/renderers/BooleanSymbolCell.tsx
@@ -13,7 +13,6 @@ import type { ColumnCellProps, Dimensions } from './types.js'
 
 /**
  * Symbolic rendering of boolean values.
- * TODO: this should probably be a check versus x
  */
 export const BooleanSymbolCell: React.FC<ColumnCellProps> = memo(
 	function BooleanSymbolCell({ item, column }) {
@@ -34,7 +33,6 @@ function useBooleanCircleAttrs(
 ) {
 	const theme = useThematic()
 	return useMemo(() => {
-		// TODO: helpers for extracting steeltoe table value defaults with all these optionals
 		const value = !!getValue(item, column)
 		const { width, height } = dimensions
 		return {

--- a/javascript/react/src/ArqueroDetailsList/renderers/DateCell.tsx
+++ b/javascript/react/src/ArqueroDetailsList/renderers/DateCell.tsx
@@ -13,7 +13,7 @@ import type { FormattedCellProps } from './types.js'
 export const DateCell: React.FC<FormattedCellProps> = memo(function DateCell({
 	item,
 	column,
-	textAlign = 'left',
+	textAlign = 'right',
 }) {
 	const value = getValue(item, column)
 	return (
@@ -22,7 +22,7 @@ export const DateCell: React.FC<FormattedCellProps> = memo(function DateCell({
 				textAlign,
 			}}
 		>
-			{value && (value as Date).toLocaleDateString()}
+			{value && (value as Date).toLocaleString()}
 		</div>
 	)
 })

--- a/javascript/react/src/ArqueroDetailsList/renderers/DefaultCell.tsx
+++ b/javascript/react/src/ArqueroDetailsList/renderers/DefaultCell.tsx
@@ -3,7 +3,7 @@
  * Licensed under the MIT license. See LICENSE file in the project.
  */
 
-import { DataType } from '@data-wrangling-components/core'
+import { DataType, determineType } from '@data-wrangling-components/core'
 import { memo, useCallback, useMemo } from 'react'
 import { Case, Default, Switch } from 'react-if'
 
@@ -29,7 +29,7 @@ export const DefaultCell: React.FC<RichCellProps> = memo(function DefaultCell(
 ) {
 	const { metadata, item, column, onColumnClick } = props
 	const value = getValue(item, column)
-	const type = metadata?.type ?? typeof value
+	const type = metadata?.type ?? determineType(value)
 
 	const handleColumnClick = useCallback(
 		ev => {

--- a/javascript/react/src/ArqueroDetailsList/renderers/DefaultCell.tsx
+++ b/javascript/react/src/ArqueroDetailsList/renderers/DefaultCell.tsx
@@ -41,7 +41,9 @@ export const DefaultCell: React.FC<RichCellProps> = memo(function DefaultCell(
 	)
 
 	const cellStyle = useMemo(() => {
-		const style: React.CSSProperties = {}
+		const style: React.CSSProperties = {
+			width: '100%',
+		}
 		if (onColumnClick) {
 			style.cursor = 'pointer'
 		}

--- a/javascript/react/src/ArqueroTableHeader/ArqueroTableHeader.tsx
+++ b/javascript/react/src/ArqueroTableHeader/ArqueroTableHeader.tsx
@@ -22,7 +22,6 @@ export const ArqueroTableHeader: React.FC<ArqueroTableHeaderProps> = memo(
 		commands = [],
 		farCommands = [],
 		visibleColumns,
-		visibleRows,
 		onRenameTable,
 		style,
 	}) {
@@ -33,9 +32,8 @@ export const ArqueroTableHeader: React.FC<ArqueroTableHeaderProps> = memo(
 			return table.isGrouped() ? table.groups().size : 0
 		}, [table])
 
-		// TODO: we can do the same thing for rows when a filter is applied
 		const columnCounts = useColumnCounts(table, visibleColumns)
-		const rowCounts = useRowCounts(table, visibleRows)
+		const rowCounts = useRowCounts(table)
 		return (
 			<Header bgColor={bgColor} ref={ref}>
 				{commands?.length > 0 ? (
@@ -56,13 +54,13 @@ export const ArqueroTableHeader: React.FC<ArqueroTableHeaderProps> = memo(
 					) : null}
 					{showRowCount === true ? (
 						<H3 color={textColor}>
-							{rowCounts.total} rows{' '}
-							{rowCounts.hidden > 0 ? `(${rowCounts.hidden} hidden)` : ''}
+							{rowCounts.visible} rows{' '}
+							{rowCounts.hidden > 0 ? `(${rowCounts.hidden} filtered)` : ''}
 						</H3>
 					) : null}
 					{showColumnCount === true ? (
 						<H3 color={textColor}>
-							{columnCounts.total} cols{' '}
+							{columnCounts.visible} cols{' '}
 							{columnCounts.hidden > 0 ? `(${columnCounts.hidden} hidden)` : ''}
 						</H3>
 					) : null}

--- a/javascript/react/src/ArqueroTableHeader/hooks/useRowCounts.ts
+++ b/javascript/react/src/ArqueroTableHeader/hooks/useRowCounts.ts
@@ -5,22 +5,19 @@
 import type ColumnTable from 'arquero/dist/types/table/column-table'
 import { useMemo } from 'react'
 
-export function useRowCounts(
-	table: ColumnTable,
-	visibleRows?: number,
-): {
+export function useRowCounts(table: ColumnTable): {
 	total: number
 	visible: number
 	hidden: number
 } {
 	return useMemo(() => {
-		const total = table.numRows()
-		const visible = visibleRows ? visibleRows : total
+		const total = table.totalRows()
+		const visible = table.numRows()
 		const hidden = total - visible
 		return {
 			total,
 			visible,
 			hidden,
 		}
-	}, [table, visibleRows])
+	}, [table])
 }

--- a/javascript/react/src/ArqueroTableHeader/types.ts
+++ b/javascript/react/src/ArqueroTableHeader/types.ts
@@ -13,7 +13,6 @@ export interface ArqueroTableHeaderProps {
 	commands?: ICommandBarItemProps[]
 	farCommands?: ICommandBarItemProps[]
 	visibleColumns?: string[]
-	visibleRows?: number
 	onRenameTable?: (name: string) => void
 	style?: {
 		bgColor?: string

--- a/javascript/webapp/src/pages/DebugPage/DebugPage.tsx
+++ b/javascript/webapp/src/pages/DebugPage/DebugPage.tsx
@@ -255,7 +255,7 @@ const InputsSection = styled.div`
 `
 
 const TableSection = styled.div`
-	max-height: 300px;
+	max-height: 400px;
 `
 
 const StepsColumn = styled.div`

--- a/javascript/webapp/src/pages/DebugPage/Table.tsx
+++ b/javascript/webapp/src/pages/DebugPage/Table.tsx
@@ -142,5 +142,5 @@ const Container = styled.div`
 `
 
 const TableContainer = styled.div`
-	height: 264px;
+	height: 364px;
 `


### PR DESCRIPTION
Cleans up a few things with cell and table header rendering
- Numbers and dates are properly right-aligned
- Header now displays if rows are filtered
- Removes some TODO comments that are resolved