### PR TITLE
fix commandBar width prop and change view output button text

### DIFF
--- a/.yarn/versions/bb57d38c.yml
+++ b/.yarn/versions/bb57d38c.yml
@@ -1,0 +1,3 @@
+releases:
+  "@data-wrangling-components/react": patch
+  "@data-wrangling-components/webapp": patch

--- a/javascript/react/src/ArqueroDetailsList/hooks/useCountMinWidth.ts
+++ b/javascript/react/src/ArqueroDetailsList/hooks/useCountMinWidth.ts
@@ -15,7 +15,9 @@ export function useCountMinWidth(
 ): number {
 	return useMemo(() => {
 		const elementsWidth = Math.max(
-			...(commandBar?.map(command => +command()?.props?.style?.width) || [0]),
+			...(commandBar?.map(command => +command()?.props.styles.root.width) || [
+				0,
+			]),
 		)
 
 		const buttonsWidth =

--- a/javascript/react/src/PrepareData/TableListBar/TableListBar.tsx
+++ b/javascript/react/src/PrepareData/TableListBar/TableListBar.tsx
@@ -38,7 +38,7 @@ export const TableListBar: React.FC<{
 					iconProps={iconProps}
 					onClick={onClick}
 				>
-					View output
+					View output table
 				</DefaultButton>
 			) : null}
 


### PR DESCRIPTION
-commandBar width verification using new props style
-view output button changed to 'view output table'